### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:16
+WORKDIR /app
+COPY package*.json ./
+RUN npm config set registry https://registry.npmjs.org/ \
+    && npm install
+COPY . .
+EXPOSE 8080
+CMD ["npm", "run", "serve"]


### PR DESCRIPTION
## Summary
- add Dockerfile with Node 16 base image
- use `.dockerignore` to avoid copying unnecessary files

## Testing
- `npm install` *(fails: registry.npm.taobao.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684b7325a988832bb0a00aa46c00eb90